### PR TITLE
Expdir 173

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 ## Overview
 
 The faceted search browsers are powered by [FacetView2](https://github.com/tetherless-world/facetview2) - a pure javascript frontend for ElasticSearch search indices that let you easily embed a faceted browse front end into any web page.
-This is now just copied locally under this repo.
+This is now just copied locally under this repo because the original repositories are no longer maintained.
+Additionally, the local code has been modified to work with Elasticsearch versions > 7.
 
 To configure a working faceted browser you need:
-1. A running instance of ElasticSearch with a populated index - in this case experts.colorado.edu/es
+1. A running instance of ElasticSearch with a populated index 
+   - in this case: https://search-experts-direct-cz3fpq4rlxcbn5z27vzq4mpzaa.us-east-2.es.amazonaws.com/fispubs-v1
 2. A webpage with references to facetview2 scripts and an embedded configuration
 
 That's it!
@@ -21,11 +23,12 @@ The .html files are for standalone pages.
 
 To install these pages
 1. Copy this current repository to the target directory which will serve these assets
-2. Copy the people and publication pages to the location that will serve them
+2. Copy the publication.html page to the location that will serve them
 3. You probably have to adjust the pathing of the css and javascript assets called in the pages.
 4. You might have to adjust the search_url variable to point to the Elastic index.
+5. The production Elastic index on AWS uses basic http authentication, the username and password below are for public access so they are not a secret.
 
-Next just hit the publications.html page. It should query to our running elasticsearch instance for data
+Next just hit the publications.html page. It should query  our running elasticsearch instance for data
 
 ### Setting up the faceted browser from scratch
 
@@ -50,7 +53,9 @@ Then add a script somewhere to your page that actually calls and sets up the fac
 <script type="text/javascript">
 jQuery(document).ready(function($) {
   $('.facet-view-simple').facetview({
-    search_url: 'http://localhost:9200/myindex/type/_search',
+    search_url: 'https://search-experts-direct-cz3fpq4rlxcbn5z27vzq4mpzaa.us-east-2.es.amazonaws.com/fispubs-v1/_search',
+    username: 'anon',
+    password: 'anonyM0us!',
     facets: [
         {'field': 'publisher.exact', 'size': 100, 'order':'term', 'display': 'Publisher'},
         {'field': 'author.name.exact', 'display': 'author'},
@@ -109,7 +114,11 @@ This page won't go into details on how to construct an Elasticsearch query. Deta
 Query examples below follow formats similar to that used by the Facetview software. They consist of filters and aggregations.
 
 ### Elasticsearch endpoint on AWS server
-https://search-experts-pubs-unoedenr36fpm7alfpboeihcnq.us-east-2.es.amazonaws.com/fispubs-v1/_search
+# A username and password is required. The public credential is listed below.
+    search_url: 'https://search-experts-direct-cz3fpq4rlxcbn5z27vzq4mpzaa.us-east-2.es.amazonaws.com/fispubs-v1/_search',
+    username: 'anon',
+    password: 'anonyM0us!'
+
 
 ### Elasticsearch publication queries for common identifiers such as department ID, fisID, or email
 
@@ -134,9 +143,8 @@ Email ID ( The email ID that the individual specified via the FRPA interface ) -
 Copyright and License
 =====================
 
-Copyright 2014 Cottage Labs.
-
-Licensed under the MIT Licence
+Copyright 2014 Cottage Labs.  Licensed under the MIT Licence
+University of Colorado, Boulder - License: CC BY 4.0 (https://creativecommons.org/licenses/by/4.0/)
 
 twitter bootstrap: http://twitter.github.com/bootstrap/
 MIT License: http://www.opensource.org/licenses/mit-license.php

--- a/facetview2/es.js
+++ b/facetview2/es.js
@@ -23,7 +23,7 @@ var elasticsearch_distance_units = ["km", "mi", "miles", "in", "inch", "yd", "ya
 function optionsFromQuery(query) {
 
     function stripDistanceUnits(val) {
-        for (var i=0; i < elasticsearch_distance_units.length; i=i+1) {
+        for (var i = 0; i < elasticsearch_distance_units.length; i = i + 1) {
             var unit = elasticsearch_distance_units[i];
             if (endsWith(val, unit)) {
                 return val.substring(0, val.length - unit.length)
@@ -49,36 +49,36 @@ function optionsFromQuery(query) {
 
         return val;
     }
-    
+
     var opts = {};
 
     // FIXME: note that fields are not supported here
 
     // from position
     if (query.hasOwnProperty("from")) { opts["from"] = query.from }
-    
+
     // page size
     if (query.size) { opts["page_size"] = query.size }
-    
+
     if (query["sort"]) { opts["sort"] = query["sort"] }
-    
+
     // get hold of the bool query if it is there
     // and get hold of the query string and default operator if they have been provided
     if (query.query) {
         var sq = query.query;
         var must = [];
         var qs = undefined;
-        
+
         // if this is a filtered query, pull must and qs out of the filter
         // otherwise the root of the query is the query_string object
         if (sq.bool) {
-//DRE 1.7            must = sq.bool.filter.bool.must;
+            //DRE 1.7            must = sq.bool.filter.bool.must;
             must = sq.bool.must;
             qs = sq.bool.query
         } else {
             qs = sq
         }
-        
+
         // go through each clause in the must and pull out the options
         if (must.length > 0) {
             opts["_active_filters"] = {};
@@ -86,7 +86,7 @@ function optionsFromQuery(query) {
         }
         for (var i = 0; i < must.length; i++) {
             var clause = must[i];
-            
+
             // could be a term query (implies AND on this field)
             if ("term" in clause) {
                 for (var field in clause.term) {
@@ -100,10 +100,10 @@ function optionsFromQuery(query) {
                     }
                 }
             }
-            
+
             // could be a terms query (implies OR on this field)
             if ("terms" in clause) {
-                for (var field=0; field < clause.terms.length; field=field+1) {
+                for (var field = 0; field < clause.terms.length; field = field + 1) {
                     opts["_selected_operators"][field] = "OR";
                     var values = clause.terms[field];
                     if (!(field in opts["_active_filters"])) {
@@ -112,7 +112,7 @@ function optionsFromQuery(query) {
                     opts["_active_filters"][field] = opts["_active_filters"][field].concat(values)
                 }
             }
-            
+
             // could be a range query (which may in turn be a range or a date histogram facet)
             if ("range" in clause) {
                 // get the field that we're ranging on
@@ -131,20 +131,20 @@ function optionsFromQuery(query) {
                     opts["_active_filters"][field] = range;
                 }
             }
-            
+
             // cound be a geo distance query
             if ("geo_distance_range" in clause) {
                 var gdr = clause.geo_distance_range;
-                
+
                 // the range is defined at the root of the range filter
                 var range = {};
                 if ("lt" in gdr) { range["to"] = stripDistanceUnits(gdr.lt) }
                 if ("gte" in gdr) { range["from"] = stripDistanceUnits(gdr.gte) }
-                
+
                 // FIXME: at some point we may need to make this smarter, if we start including other data
                 // in the geo_distance_range filter definition
                 // then we have to go looking for the field name
-                for (var field=0; field < gdr.length; field=field+1) {
+                for (var field = 0; field < gdr.length; field = field + 1) {
                     if (field === "lt" || field === "gte") { continue }
                     opts["_active_filters"][field] = range
                     break
@@ -153,7 +153,7 @@ function optionsFromQuery(query) {
 
             // FIXME: support for statistical facet and terms_stats facet
         }
-        
+
         if (qs) {
             if (qs.query_string) {
                 var string = unescapeQueryString(qs.query_string.query);
@@ -166,7 +166,7 @@ function optionsFromQuery(query) {
                 opts["q"] = ""
             }
         }
-        
+
         return opts
     }
 }
@@ -189,22 +189,22 @@ function getFilters(params) {
     function termsFilter(facet, filter_list) {
         if (facet.logic === "AND") {
             var filters = [];
-            for (var i=0; i < filter_list.length; i=i+1) {
+            for (var i = 0; i < filter_list.length; i = i + 1) {
                 var value = filter_list[i];
-                var tq = {"term" : {}};
+                var tq = { "term": {} };
                 tq["term"][facet.field] = value;
                 filters.push(tq);
             }
             return filters;
         } else if (facet.logic === "OR") {
-            var tq = {"terms" : {}};
+            var tq = { "terms": {} };
             tq["terms"][facet.field] = filter_list;
             return [tq];
         }
     }
 
     function rangeFilter(facet, value) {
-        var rq = {"range" : {}};
+        var rq = { "range": {} };
         rq["range"][facet.field] = {};
         if (value.to) { rq["range"][facet.field]["lt"] = value.to }
         if (value.from) { rq["range"][facet.field]["gte"] = value.from }
@@ -212,7 +212,7 @@ function getFilters(params) {
     }
 
     function geoFilter(facet, value) {
-        var gq = {"geo_distance_range" : {}};
+        var gq = { "geo_distance_range": {} };
         if (value.to) { gq["geo_distance_range"]["lt"] = value.to + facet.unit }
         if (value.from) { gq["geo_distance_range"]["gte"] = value.from + facet.unit }
         gq["geo_distance_range"][facet.field] = [facet.lon, facet.lat]; // note the order of lon/lat to comply with GeoJSON
@@ -220,7 +220,7 @@ function getFilters(params) {
     }
 
     function dateHistogramFilter(facet, value) {
-        var rq = {"range" : {}};
+        var rq = { "range": {} };
         rq["range"][facet.field] = {};
         if (value.to) { rq["range"][facet.field]["lt"] = value.to }
         if (value.from) { rq["range"][facet.field]["gte"] = value.from }
@@ -276,7 +276,7 @@ function elasticSearchQuery(params) {
     var include_facets = "include_facets" in params ? params.include_facets : true;
     var include_fields = "include_fields" in params ? params.include_fields : true;
 
-    var filter_must = getFilters({"options" : options});
+    var filter_must = getFilters({ "options": options });
 
     // search string and search field produce a query_string query element
     var querystring = options.q;
@@ -284,7 +284,7 @@ function elasticSearchQuery(params) {
     var default_operator = options.default_operator;
     var ftq = undefined;
     if (querystring) {
-        ftq = {'query_string' : { 'query': fuzzify(querystring, options.default_freetext_fuzzify) }};
+        ftq = { 'query_string': { 'query': fuzzify(querystring, options.default_freetext_fuzzify) } };
         if (searchfield) {
             ftq.query_string["default_field"] = searchfield
         }
@@ -292,35 +292,35 @@ function elasticSearchQuery(params) {
             ftq.query_string["default_operator"] = default_operator
         }
     } else {
-        ftq = {"match_all" : {}}
+        ftq = { "match_all": {} }
     }
-    
+
     // if there are filter constraints (filter_must) then we create a filtered query,
     // otherwise make a normal query
     // DRE -- no queries under filters, query_string needs to be under "must"
     // DRE -- also "match_all" the ftq var is in the wrong location and doesn't conform anymore
     var qs = undefined;
     if (filter_must.length > 0) {
- //DRE 1.7       qs = {"query" : {"bool" : {"filter" : {"bool" : {"must" : filter_must}}}}};
-        qs = {"query" : {"bool" : {"must" : filter_must}}};
-//DRE 1.7        qs.query.bool["query"] = ftq;
+        //DRE 1.7       qs = {"query" : {"bool" : {"filter" : {"bool" : {"must" : filter_must}}}}};
+        qs = { "query": { "bool": { "must": filter_must } } };
+        //DRE 1.7        qs.query.bool["query"] = ftq;
         qs.query.bool.must.push(ftq);
     } else {
-        qs = {"query" : ftq}
+        qs = { "query": ftq }
     }
-    
+
     qs["track_total_hits"] = options.track_total_hits
 
     // sort order and direction
     options.sort && options.sort.length > 0 ? qs['sort'] = options.sort : "";
-    
+
     // fields and partial fields
     if (include_fields) {
         options.fields ? qs['fields'] = options.fields : "";
         options.partial_fields ? qs['partial_fields'] = options.partial_fields : "";
         options.script_fields ? qs["script_fields"] = options.script_fields : "";
     }
-    
+
     // paging (number of results, and start cursor)
     if (options.from !== undefined) {
         qs["from"] = options.from
@@ -328,7 +328,7 @@ function elasticSearchQuery(params) {
     if (options.page_size !== undefined) {
         qs["size"] = options.page_size
     }
-    
+
     // facets
     if (include_facets) {
         qs['aggs'] = {};
@@ -337,40 +337,40 @@ function elasticSearchQuery(params) {
             if (defn.disabled) { continue }
 
             var size = defn.size;
-            
+
             // add a bunch of extra values to the facets to deal with the shard count issue
-            size += options.elasticsearch_facet_inflation 
-            
+            size += options.elasticsearch_facet_inflation
+
             var facet = {};
             if (defn.type === "terms") {
                 var order = {}
-                order.count={"_count":"desc"}
-                order.reverse_count={"_count":"asc"}
-                order.term={"_key":"desc"}
-                order.reverse_term={"_key":"asc"}
-//DRE new order is an object                facet["terms"] = {"field" : defn["field"], "size" : size, "order" : defn["order"]}
-                facet["terms"] = {"field" : defn["field"], "size" : size, "order" : order[defn["order"]]}
-//                facet["terms"] = {"field" : defn["field"], "size" : size, "order" : {defn["order"]}}
+                order.count = { "_count": "desc" }
+                order.reverse_count = { "_count": "asc" }
+                order.term = { "_key": "desc" }
+                order.reverse_term = { "_key": "asc" }
+                //DRE new order is an object                facet["terms"] = {"field" : defn["field"], "size" : size, "order" : defn["order"]}
+                facet["terms"] = { "field": defn["field"], "size": size, "order": order[defn["order"]] }
+                //                facet["terms"] = {"field" : defn["field"], "size" : size, "order" : {defn["order"]}}
             } else if (defn.type === "range") {
                 var ranges = [];
-                for (var r=0; r < defn["range"].length; r=r+1) {
+                for (var r = 0; r < defn["range"].length; r = r + 1) {
                     var def = defn["range"][r];
                     var robj = {};
                     if (def.to) { robj["to"] = def.to }
                     if (def.from) { robj["from"] = def.from }
                     ranges.push(robj)
                 }
-                facet["range"] = { };
+                facet["range"] = {};
                 var r = {};
-                r.field=defn["field"]
-                r.ranges=ranges
+                r.field = defn["field"]
+                r.ranges = ranges
                 facet["range"] = r
             } else if (defn.type === "geo_distance") {
                 facet["geo_distance"] = {}
                 facet["geo_distance"][defn["field"]] = [defn.lon, defn.lat]; // note that the order is lon/lat because of GeoJSON
                 facet["geo_distance"]["unit"] = defn.unit;
                 var ranges = [];
-                for (var r=0; r < defn["distance"].length; r=r+1) {
+                for (var r = 0; r < defn["distance"].length; r = r + 1) {
                     var def = defn["distance"][r];
                     var robj = {};
                     if (def.to) { robj["to"] = def.to }
@@ -379,22 +379,22 @@ function elasticSearchQuery(params) {
                 }
                 facet["geo_distance"]["ranges"] = ranges
             } else if (defn.type === "statistical") {
-                facet["statistical"] = {"field" : defn["field"]}
+                facet["statistical"] = { "field": defn["field"] }
             } else if (defn.type === "terms_stats") {
-                facet["terms_stats"] = {key_field : defn["field"], value_field: defn["value_field"], size : size, order : defn["order"]}
+                facet["terms_stats"] = { key_field: defn["field"], value_field: defn["value_field"], size: size, order: defn["order"] }
             } else if (defn.type === "date_histogram") {
-                facet["date_histogram"] = {field : defn["field"], interval : defn["interval"]}
+                facet["date_histogram"] = { field: defn["field"], interval: defn["interval"] }
             }
             qs["aggs"][defn["field"]] = facet
         }
-        
+
         // and any extra facets
         // NOTE: this does not include any treatment of the facet size inflation that may be required
         if (options.extra_facets) {
-            $.extend(true, qs['aggs'], options.extra_facets );
+            $.extend(true, qs['aggs'], options.extra_facets);
         }
     }
-    
+
     return qs
 }
 
@@ -405,9 +405,9 @@ function fuzzify(querystr, default_freetext_fuzzify) {
             if (querystr.indexOf('*') === -1 && querystr.indexOf('~') === -1 && querystr.indexOf(':') === -1) {
                 var optparts = querystr.split(' ');
                 pq = "";
-                for ( var oi = 0; oi < optparts.length; oi++ ) {
+                for (var oi = 0; oi < optparts.length; oi++) {
                     var oip = optparts[oi];
-                    if ( oip.length > 0 ) {
+                    if (oip.length > 0) {
                         oip = oip + default_freetext_fuzzify;
                         default_freetext_fuzzify == "*" ? oip = "*" + oip : false;
                         pq += oip + " ";
@@ -427,7 +427,7 @@ function jsonStringEscape(key, value) {
     }
 
     function replaceAll(string, find, replace) {
-      return string.replace(new RegExp(escapeRegExp(find), 'g'), replace);
+        return string.replace(new RegExp(escapeRegExp(find), 'g'), replace);
     }
 
     function paired(string, pair) {
@@ -438,7 +438,7 @@ function jsonStringEscape(key, value) {
     // if we are looking at the query string, make sure that it is escaped
     // (note that this precludes the use of queries like "name:bob", as the ":" would
     // get escaped)
-    if (key === "query" && typeof(value) === 'string') {
+    if (key === "query" && typeof (value) === 'string') {
 
         var scs = esSpecialCharsSubSet.slice(0);
 
@@ -467,14 +467,14 @@ function serialiseQueryObject(qs) {
 // closure for elastic search success, which ultimately calls
 // the user's callback
 function elasticSearchSuccess(callback) {
-    return function(data) {
+    return function (data) {
         var resultobj = {
-            "records" : [],
-            "start" : "",
-            "found" : data.hits.total.value,
-            "facets" : {}
+            "records": [],
+            "start": "",
+            "found": data.hits.total.value,
+            "facets": {}
         };
-        
+
         // load the results into the records part of the result object
         for (var item = 0; item < data.hits.hits.length; item++) {
             var res = data.hits.hits[item];
@@ -485,7 +485,7 @@ function elasticSearchSuccess(callback) {
                 resultobj.records.push(res._source)
             }
         }
-        
+
         for (var item in data.facets) {
             if (data.facets.hasOwnProperty(item)) {
                 var facet = data.facets[item];
@@ -494,14 +494,14 @@ function elasticSearchSuccess(callback) {
                 if ("terms" in facet) {
                     var terms = facet["terms"];
                     resultobj["facets"][item] = terms;
-                // handle any range/geo_distance_range facets
+                    // handle any range/geo_distance_range facets
                 } else if ("ranges" in facet) {
                     var range = facet["ranges"];
                     resultobj["facets"][item] = range;
-                // handle statistical facets
+                    // handle statistical facets
                 } else if (facet["_type"] === "statistical") {
                     resultobj["facets"][item] = facet;
-                // handle terms_stats
+                    // handle terms_stats
                 } else if (facet["_type"] === "terms_stats") {
                     var terms = facet["terms"];
                     resultobj["facets"][item] = terms
@@ -511,7 +511,7 @@ function elasticSearchSuccess(callback) {
                 }
             }
         }
-            
+
         callback(data, resultobj)
     }
 }
@@ -521,19 +521,24 @@ function doElasticSearchQuery(params) {
     var success_callback = params.success;
     var complete_callback = params.complete;
     var search_url = params.search_url;
+    var username = params.username;
+    var password = params.password;
     var queryobj = params.queryobj;
     var datatype = params.datatype;
     var contenttype = "application/json"
-    
+
     // serialise the query
     var querystring = serialiseQueryObject(queryobj);
-    
+
     // make the call to the elasticsearch web service
     $.ajax({
         type: "get",
         url: search_url,
-        data: {source_content_type: contenttype, source: querystring},
+        data: { source_content_type: contenttype, source: querystring },
         dataType: datatype,
+        beforeSend: function (xhr) {
+            xhr.setRequestHeader("Authorization", "Basic " + btoa(username + ':' + password));
+        },
         contentType: contenttype,
         source_content_type: contenttype,
         success: elasticSearchSuccess(success_callback),

--- a/facetview2/es.js
+++ b/facetview2/es.js
@@ -537,7 +537,9 @@ function doElasticSearchQuery(params) {
         data: { source_content_type: contenttype, source: querystring },
         dataType: datatype,
         beforeSend: function (xhr) {
-            xhr.setRequestHeader("Authorization", "Basic " + btoa(username + ':' + password));
+            if (username != null) {
+                xhr.setRequestHeader("Authorization", "Basic " + btoa(username + ':' + password));
+            }
         },
         contentType: contenttype,
         source_content_type: contenttype,

--- a/facetview2/jquery.facetview2.js
+++ b/facetview2/jquery.facetview2.js
@@ -14,7 +14,7 @@
 // Deal with indexOf issue in <IE9
 // provided by commentary in repo issue - https://github.com/okfn/facetview/issues/18
 if (!Array.prototype.indexOf) {
-    Array.prototype.indexOf = function(searchElement /*, fromIndex */ ) {
+    Array.prototype.indexOf = function (searchElement /*, fromIndex */) {
         "use strict";
         if (this == null) {
             throw new TypeError();
@@ -52,12 +52,12 @@ if (!Array.prototype.indexOf) {
 
 // first define the bind with delay function from (saves loading it separately) 
 // https://github.com/bgrins/bindWithDelay/blob/master/bindWithDelay.js
-(function($) {
-    $.fn.bindWithDelay = function( type, data, fn, timeout, throttle ) {
+(function ($) {
+    $.fn.bindWithDelay = function (type, data, fn, timeout, throttle) {
         var wait = null;
         var that = this;
 
-        if ( $.isFunction( data ) ) {
+        if ($.isFunction(data)) {
             throttle = timeout;
             timeout = fn;
             fn = data;
@@ -65,8 +65,8 @@ if (!Array.prototype.indexOf) {
         }
 
         function cb() {
-            var e = $.extend(true, { }, arguments[0]);
-            var throttler = function() {
+            var e = $.extend(true, {}, arguments[0]);
+            var throttler = function () {
                 wait = null;
                 fn.apply(that, [e]);
             };
@@ -80,7 +80,7 @@ if (!Array.prototype.indexOf) {
 })(jQuery);
 
 function safeId(s) {
-    return s.replace(/\./gi,'_').replace(/\:/gi,'_').replace(/@/, '_');
+    return s.replace(/\./gi, '_').replace(/\:/gi, '_').replace(/@/, '_');
 }
 
 // get the right facet element from the page
@@ -121,7 +121,7 @@ function ie8compat(o) {
             }
         }
         if (recurse) {
-            for ( var each = 0; each < array.length; each++ ) {
+            for (var each = 0; each < array.length; each++) {
                 if ($.type(array[each]) == 'array') {
                     delete_last_element_of_array_if_undefined(array[each], true);
                 }
@@ -130,7 +130,7 @@ function ie8compat(o) {
     }
 
     // first see if this clean up is necessary at all
-    var test = ["a", "b", "c", ];  // note trailing comma, will produce ["a", "b", "c", undefined] in IE8 and ["a", "b", "c"] in every sane browser
+    var test = ["a", "b", "c",];  // note trailing comma, will produce ["a", "b", "c", undefined] in IE8 and ["a", "b", "c"] in every sane browser
     if ($.type(test[test.length - 1]) == 'undefined') {
         // ok, cleanup is necessary, go
         for (var key in o) {
@@ -145,20 +145,20 @@ function ie8compat(o) {
 /******************************************************************
  * DEFAULT CALLBACKS
  *****************************************************************/
- 
+
 ///// the lifecycle callbacks ///////////////////////
-function postInit(options, context) {}
-function preSearch(options, context) {}
-function postSearch(options, context) {}
-function preRender(options, context) {}
-function postRender(options, context) {}
+function postInit(options, context) { }
+function preSearch(options, context) { }
+function postSearch(options, context) { }
+function preRender(options, context) { }
+function postRender(options, context) { }
 
 /******************************************************************
  * URL MANAGEMENT
  *****************************************************************/
 
 function shareableUrl(options, query_part_only, include_fragment) {
-    var source = elasticSearchQuery({"options" : options, "include_facets" : options.include_facets_in_url, "include_fields" : options.include_fields_in_url})
+    var source = elasticSearchQuery({ "options": options, "include_facets": options.include_facets_in_url, "include_fields": options.include_fields_in_url })
     var querypart = "?source_content_type=application%2Fjson&source=" + encodeURIComponent(serialiseQueryObject(source))
     include_fragment = include_fragment === undefined ? true : include_fragment
     if (include_fragment) {
@@ -188,7 +188,7 @@ function getUrlVars() {
                 // if it looks like a JSON object in string form...
                 // remove " (double quotes) at beginning and end of string to make it a valid 
                 // representation of a JSON object, or the parser will complain
-                newval = newval.replace(/^"/,"").replace(/"$/,"");
+                newval = newval.replace(/^"/, "").replace(/"$/, "");
                 var newval = JSON.parse(newval);
             }
             params[hash[0]] = newval;
@@ -197,80 +197,85 @@ function getUrlVars() {
     if (anchor) {
         params['url_fragment_identifier'] = anchor;
     }
-    
+
     return params;
 }
- 
+
 /******************************************************************
  * FACETVIEW ITSELF
  *****************************************************************/
 
-(function($){
-    $.fn.facetview = function(options) {
-    
+(function ($) {
+    $.fn.facetview = function (options) {
+
 
         // Load the Altmetric badge script
-        $.getScript("https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js", function(){});
-        
+        $.getScript("https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js", function () { });
+
         /**************************************************************
          * handle the incoming options, default options and url parameters
          *************************************************************/
-         
+
         // all of the possible options that will be used in the facetview lifecycle
         // along with their documentation
         var defaults = {
             ///// elasticsearch parameters /////////////////////////////
-            
-            "track_total_hits" : "true",
+
+            "track_total_hits": "true",
 
             // the base search url which will respond to elasticsearch queries.  Generally ends with _search
-            "search_url" : "http://localhost:9200/_search",
-            
+            "search_url": "http://localhost:9200/_search",
+
+            // username and password for http basic_auth - new for CU Boulder
+            "username": "anon",
+            "password": "anon",
+
             // datatype for ajax requests to use - overall recommend using jsonp
-//DRE            "datatype" : "jsonp",
-            
+            //DRE            "datatype" : "jsonp",
+            "datatype": "json",
+
             // if set, should be either * or ~
             // if *, * will be prepended and appended to each string in the freetext search term
             // if ~, ~ then ~ will be appended to each string in the freetext search term. 
             // If * or ~ or : are already in the freetext search term, no action will be taken. 
             "default_freetext_fuzzify": false, // or ~ or *
-            
+
             // due to a bug in elasticsearch's clustered node facet counts, we need to inflate
             // the number of facet results we need to ensure that the results we actually want are
             // accurate.  This option tells us by how much.
             // DRE 2019-02-04 --- verify if this is still a bug and how this works
-            "elasticsearch_facet_inflation" : 100,
-            
+            "elasticsearch_facet_inflation": 100,
+
             ///// query aspects /////////////////////////////
-            
+
             // list of fields to be returned by the elasticsearch query.  If omitted, full result set is returned
-            "fields" : false, // or an array of field names
-            
+            "fields": false, // or an array of field names
+
             // list of partial fields to be returned by the elasticsearch query.  If omitted, full result set is returned
-            "partial_fields" : false, // or an array of partial fields
+            "partial_fields": false, // or an array of partial fields
 
             // list of script fields to be executed.  Note that you should, in general, not pass actual scripts but
             // references to stored scripts in the back-end ES.  If not false, then an object corresponding to the
             // ES script_fields structure
-            "script_fields" : false,
-            
+            "script_fields": false,
+
             // number of results to display per page (i.e. to retrieve per query)
-            "page_size" : 10,
-            
+            "page_size": 10,
+
             // cursor position in the elasticsearch result set
-            "from" : 0,
-            
+            "from": 0,
+
             // list of fields and directions to sort in.  Note that the UI only supports single value sorting
-            "sort" : [], // or something like [ {"title" : {"order" : "asc"}} ]
-            
+            "sort": [], // or something like [ {"title" : {"order" : "asc"}} ]
+
             // field on which to focus the freetext search
-            "searchfield" : "", // e.g. title.exact
-            
+            "searchfield": "", // e.g. title.exact
+
             // freetext search string
-            "q" : "",
-            
+            "q": "",
+
             ///// facet aspects /////////////////////////////
-            
+
             // The list of facets to be displayed and used to seed the filtering processes.
             // Facets are complex fields which can look as follows:
             /*
@@ -321,273 +326,273 @@ function getUrlVars() {
                 "values" : <object>                                                 // the values associated with a successful query on this facet
             }
             */
-            "facets" : [],
-            
+            "facets": [],
+
             // user defined extra facets.  These must be pre-formatted for elasticsearch, and they will
             // simply be added to the query at query-time.
             "extra_facets": {},
-            
+
             // default settings for each of the facet properties above.  If a facet lacks a property, it will
             // be initialised to the default
-            "default_facet_type" : "terms",
-            "default_facet_open" : false,
-            "default_facet_hidden" : false,
-            "default_facet_size" : 10,
-            "default_facet_operator" : "AND",  // logic
-            "default_facet_order" : "desc",
-            "default_facet_hide_inactive" : false,
-            "default_facet_deactivate_threshold" : 0, // equal to or less than this number will deactivate the facet
-            "default_facet_controls" : true,
-            "default_hide_empty_range" : true,
-            "default_hide_empty_distance" : true,
-            "default_distance_unit" : "km",
-            "default_distance_lat" : 51.4768,       // Greenwich meridian (give or take a few decimal places)
-            "default_distance_lon" : 0.0,           //
-            "default_date_histogram_interval" : "year",
-            "default_hide_empty_date_bin" : true,
-            "default_date_histogram_sort" : "asc",
-            "default_short_display" : false,
-            "default_ignore_empty_string" : false,      // because filtering out empty strings is less performant
+            "default_facet_type": "terms",
+            "default_facet_open": false,
+            "default_facet_hidden": false,
+            "default_facet_size": 10,
+            "default_facet_operator": "AND",  // logic
+            "default_facet_order": "desc",
+            "default_facet_hide_inactive": false,
+            "default_facet_deactivate_threshold": 0, // equal to or less than this number will deactivate the facet
+            "default_facet_controls": true,
+            "default_hide_empty_range": true,
+            "default_hide_empty_distance": true,
+            "default_distance_unit": "km",
+            "default_distance_lat": 51.4768,       // Greenwich meridian (give or take a few decimal places)
+            "default_distance_lon": 0.0,           //
+            "default_date_histogram_interval": "year",
+            "default_hide_empty_date_bin": true,
+            "default_date_histogram_sort": "asc",
+            "default_short_display": false,
+            "default_ignore_empty_string": false,      // because filtering out empty strings is less performant
 
 
             ///// search bar configuration /////////////////////////////
-            
+
             // list of options by which the search results can be sorted
             // of the form of a list of: { 'display' : '<display name>', 'field' : '<field to sort by>'},
-            "search_sortby" : [],
-            
+            "search_sortby": [],
+
             // list of options for fields to which free text search can be constrained
             // of the form of a list of: { 'display' : '<display name>', 'field' : '<field to search on>'},
-            "searchbox_fieldselect" : [],
-            
+            "searchbox_fieldselect": [],
+
             // enable the share/save link feature
-            "sharesave_link" : true,
+            "sharesave_link": true,
 
             // provide a function which will do url shortening for the sharesave_link box
-            "url_shortener" : false,
-            
+            "url_shortener": false,
+
             // on free-text search, default operator for the elasticsearch query system to use
-            "default_operator" : "OR",
-            
+            "default_operator": "OR",
+
             // enable the search button
-            "search_button" : false,
-            
+            "search_button": false,
+
             // amount of time between finishing typing and when a query is executed from the search box
-            "freetext_submit_delay" : 500,
-            
+            "freetext_submit_delay": 500,
+
             ///// url configuration /////////////////////////////
-            
+
             // FIXME: should we read in facets from urls, and if we do, what should we do about them?
             // should facets be included in shareable urls.  Turning this on makes them very long, and currently
             // facetview does not read those facets back in if the URLs are parsed
-            "include_facets_in_url" : false,
-            
+            "include_facets_in_url": false,
+
             // FIXME: should we read in fields from urls, and if we do, what should we do about them?
             // should fields be included in shareable urls.  Turning this on makes them very long, and currently
             // facetview does not read those fields back in if the URLs are parsed
-            "include_fields_in_url" : false,
-            
+            "include_fields_in_url": false,
+
             ///// selected filters /////////////////////////////
-            
+
             // should the facet navigation show filters alongside other facet results which have not been selected
-            "selected_filters_in_facet" : true,
-            
+            "selected_filters_in_facet": true,
+
             // should the "selected filters" area show the name of the facet from which the filter was selected
-            "show_filter_field" : true,
-            
+            "show_filter_field": true,
+
             // should the "selected filters" area show the boolean logic used by the filter (taken from the facet.logic configuration)
-            "show_filter_logic" : true,
-            
+            "show_filter_logic": true,
+
             // FIXME: add support for pre-defined range filters
             // a set of pre-defined filters which will always be applied to the search.
             // Has the following structure, and works for terms filters only
             // { "<field>" : ["<list of values>"] }
             // requires a facet for the given field to be defined
-            "predefined_filters" : {},
-            
+            "predefined_filters": {},
+
             // exclude any values that appear in pre-defined filters from any facets
             // This prevents configuration-set filters from ever being seen in a facet, but ensures that
             // they are always included when the search is carried out
-            "exclude_predefined_filters_from_facets" : true,
-            
+            "exclude_predefined_filters_from_facets": true,
+
             // current active filters
             // DO NOT USE - this is for tracking internal state ONLY
-            "active_filters" : {},
-            
+            "active_filters": {},
+
             ///// general behaviour /////////////////////////////
-            
+
             // after initialisation, begin automatically with a search
-            "initialsearch" : true,
-            
+            "initialsearch": true,
+
             // enable debug.  If debug is enabled, some technical information will be dumped to a 
             // visible textarea on the screen
-            "debug" : false,
-            
+            "debug": false,
+
             // after search, the results will fade in over this number of milliseconds
-            "fadein" : 800,
-            
+            "fadein": 800,
+
             // should the search url be synchronised with the browser's url bar after search
             // NOTE: does not work in some browsers.  See also share/save link option.
-            "pushstate" : true,
-            
+            "pushstate": true,
+
             ///// render functions /////////////////////////////
-            
+
             // for each render function, see the reference implementation for documentation on how they should work
-            
+
             // render the frame within which the facetview sits
-            "render_the_facetview" : theFacetview,
-            
+            "render_the_facetview": theFacetview,
+
             // render the search options - containing freetext search, sorting, etc
-            "render_search_options" : searchOptions,
-            
+            "render_search_options": searchOptions,
+
             // render the list of available facets.  This will in turn call individual render methods
             // for each facet type
-            "render_facet_list" : facetList,
-            
+            "render_facet_list": facetList,
+
             // render the terms facet, the list of values, and the value itself
-            "render_terms_facet" : renderTermsFacet,                 // overall framework for a terms facet
-            "render_terms_facet_values" : renderTermsFacetValues,    // the list of terms facet values
-            "render_terms_facet_result" : renderTermsFacetResult,    // individual terms facet values
-            
+            "render_terms_facet": renderTermsFacet,                 // overall framework for a terms facet
+            "render_terms_facet_values": renderTermsFacetValues,    // the list of terms facet values
+            "render_terms_facet_result": renderTermsFacetResult,    // individual terms facet values
+
             // render the range facet, the list of values, and the value itself
-            "render_range_facet" : renderRangeFacet,                // overall framework for a range facet
-            "render_range_facet_values" : renderRangeFacetValues,   // the list of range facet values
-            "render_range_facet_result" : renderRangeFacetResult,   // individual range facet values
-            
+            "render_range_facet": renderRangeFacet,                // overall framework for a range facet
+            "render_range_facet_values": renderRangeFacetValues,   // the list of range facet values
+            "render_range_facet_result": renderRangeFacetResult,   // individual range facet values
+
             // render the geo distance facet, the list of values and the value itself
-            "render_geo_facet" : renderGeoFacet,                // overall framework for a geo distance facet
-            "render_geo_facet_values" : renderGeoFacetValues,   // the list of geo distance facet values
-            "render_geo_facet_result" : renderGeoFacetResult,   // individual geo distance facet values
+            "render_geo_facet": renderGeoFacet,                // overall framework for a geo distance facet
+            "render_geo_facet_values": renderGeoFacetValues,   // the list of geo distance facet values
+            "render_geo_facet_result": renderGeoFacetResult,   // individual geo distance facet values
 
             // render the date histogram facet
-            "render_date_histogram_facet" : renderDateHistogramFacet,
-            "render_date_histogram_values" : renderDateHistogramValues,
-            "render_date_histogram_result" : renderDateHistogramResult,
-            
+            "render_date_histogram_facet": renderDateHistogramFacet,
+            "render_date_histogram_values": renderDateHistogramValues,
+            "render_date_histogram_result": renderDateHistogramResult,
+
             // render any searching notification (which will then be shown/hidden as needed)
-            "render_searching_notification" : searchingNotification,
-            
+            "render_searching_notification": searchingNotification,
+
             // render the paging controls
-            "render_results_metadata" : basicPager, // or pageSlider
-            
+            "render_results_metadata": basicPager, // or pageSlider
+
             // render a "results not found" message
-            "render_not_found" : renderNotFound,
-            
+            "render_not_found": renderNotFound,
+
             // render an individual result record
-            "render_result_record" : renderResultRecord,
-            
+            "render_result_record": renderResultRecord,
+
             // render a terms filter interface component (e.g. the filter name, boolean operator used, and selected values)
-            "render_active_terms_filter" : renderActiveTermsFilter,
-            
+            "render_active_terms_filter": renderActiveTermsFilter,
+
             // render a range filter interface component (e.g. the filter name and the human readable description of the selected range)
-            "render_active_range_filter" : renderActiveRangeFilter,
-            
+            "render_active_range_filter": renderActiveRangeFilter,
+
             // render a geo distance filter interface component (e.g. the filter name and the human readable description of the selected range)
-            "render_active_geo_filter" : renderActiveGeoFilter,
+            "render_active_geo_filter": renderActiveGeoFilter,
 
             // render a date histogram/range interface component (e.g. the filter name and the human readable description of the selected range)
-            "render_active_date_histogram_filter" : renderActiveDateHistogramFilter,
-            
+            "render_active_date_histogram_filter": renderActiveDateHistogramFilter,
+
             ///// configs for standard render functions /////////////////////////////
-            
+
             // if you provide your own render functions you may or may not want to re-use these
-            "resultwrap_start":"<tr><td>",
-            "resultwrap_end":"</td></tr>",
-            "result_display" : [ [ {"pre" : "<strong>ID</strong>:", "field": "id", "post" : "<br><br>"} ] ],
-            "results_render_callbacks" : {},
-            
+            "resultwrap_start": "<tr><td>",
+            "resultwrap_end": "</td></tr>",
+            "result_display": [[{ "pre": "<strong>ID</strong>:", "field": "id", "post": "<br><br>" }]],
+            "results_render_callbacks": {},
+
             ///// behaviour functions /////////////////////////////
-            
+
             // called at the start of searching to display the searching notification
-            "behaviour_show_searching" : showSearchingNotification,
-            
+            "behaviour_show_searching": showSearchingNotification,
+
             // called at the end of searching to hide the searching notification
-            "behaviour_finished_searching" : hideSearchingNotification,
-            
+            "behaviour_finished_searching": hideSearchingNotification,
+
             // called after rendering a facet to determine whether it is visible/disabled
-            "behaviour_facet_visibility" : setFacetVisibility,
-            
+            "behaviour_facet_visibility": setFacetVisibility,
+
             // called after rendering a facet to determine whether it should be open or closed
-            "behaviour_toggle_facet_open" : setFacetOpenness,
-            
+            "behaviour_toggle_facet_open": setFacetOpenness,
+
             // called after changing the result set order to update the search bar
-            "behaviour_results_ordering" : setResultsOrder,
+            "behaviour_results_ordering": setResultsOrder,
 
             // called when the page size is changed
-            "behaviour_set_page_size" : setUIPageSize,
+            "behaviour_set_page_size": setUIPageSize,
 
             // called when the page order is changed
-            "behaviour_set_order" : setUIOrder,
+            "behaviour_set_order": setUIOrder,
 
             // called when the field we order by is changed
-            "behaviour_set_order_by" : setUIOrderBy,
+            "behaviour_set_order_by": setUIOrderBy,
 
             // called when the search field is changed
-            "behaviour_set_search_field" : setUISearchField,
+            "behaviour_set_search_field": setUISearchField,
 
             // called when the search string is set or updated
-            "behaviour_set_search_string" : setUISearchString,
+            "behaviour_set_search_string": setUISearchString,
 
             // called when the facet size has been changed
-            "behaviour_set_facet_size" : setUIFacetSize,
+            "behaviour_set_facet_size": setUIFacetSize,
 
             // called when the facet sort order has changed
-            "behaviour_set_facet_sort" : setUIFacetSort,
+            "behaviour_set_facet_sort": setUIFacetSort,
 
             // called when the facet And/Or setting has been changed
-            "behaviour_set_facet_and_or" : setUIFacetAndOr,
+            "behaviour_set_facet_and_or": setUIFacetAndOr,
 
             // called when the selected filters have changed
-            "behaviour_set_selected_filters" : setUISelectedFilters,
+            "behaviour_set_selected_filters": setUISelectedFilters,
 
             // called when the share url is shortened/lengthened
-            "behaviour_share_url" : setUIShareUrlChange,
+            "behaviour_share_url": setUIShareUrlChange,
 
-            "behaviour_date_histogram_showall" : dateHistogramShowAll,
-            "behaviour_date_histogram_showless" : dateHistogramShowLess,
-            
+            "behaviour_date_histogram_showall": dateHistogramShowAll,
+            "behaviour_date_histogram_showless": dateHistogramShowLess,
+
             ///// lifecycle callbacks /////////////////////////////
-            
+
             // the default callbacks don't have any effect - replace them as needed
-            
-            "post_init_callback" : postInit,
-            "pre_search_callback" : preSearch,
-            "post_search_callback" : postSearch,
-            "pre_render_callback" : preRender,
-            "post_render_callback" : postRender,
-            
+
+            "post_init_callback": postInit,
+            "pre_search_callback": preSearch,
+            "post_search_callback": postSearch,
+            "pre_render_callback": preRender,
+            "post_render_callback": postRender,
+
             ///// internal state monitoring /////////////////////////////
-            
+
             // these are used internally DO NOT USE
             // they are here for completeness and documentation
-            
+
             // is a search currently in progress
-            "searching" : false,
-            
+            "searching": false,
+
             // the raw query object
-            "queryobj" : false,
-            
+            "queryobj": false,
+
             // the raw data coming back from elasticsearch
-            "rawdata" : false,
-            
+            "rawdata": false,
+
             // the parsed data from elasticsearch
-            "data" : false,
+            "data": false,
 
             // the short url for the current search, if it has been generated
-            "current_short_url" : false,
+            "current_short_url": false,
 
             // should the short url or the long url be displayed to the user?
-            "show_short_url" : false
+            "show_short_url": false
         };
-        
+
         function deriveOptions() {
             // cleanup for ie8 purposes
             ie8compat(options);
             ie8compat(defaults);
-            
+
             // extend the defaults with the provided options
             var provided_options = $.extend(defaults, options);
-            
+
             // deal with the options that come from the url, which require some special treatment
             var url_params = getUrlVars();
             var url_options = {};
@@ -598,14 +603,14 @@ function getUrlVars() {
                 url_options["url_fragment_identifier"] = url_params["url_fragment_identifier"]
             }
             provided_options = $.extend(provided_options, url_options);
-            
+
             // copy the _selected_operators data into the relevant facets
             // for each pre-selected operator, find the related facet and set its "logic" property
             var so = provided_options._selected_operators ? provided_options._selected_operators : {};
             for (var field in so) {
                 if (so.hasOwnProperty(field)) {
                     var operator = so[field];
-                    for (var i=0; i < provided_options.facets.length; i=i+1) {
+                    for (var i = 0; i < provided_options.facets.length; i = i + 1) {
                         var facet = provided_options.facets[i];
                         if (facet.field === field) {
                             facet["logic"] = operator
@@ -616,7 +621,7 @@ function getUrlVars() {
             if ("_selected_operators" in provided_options) {
                 delete provided_options._selected_operators
             }
-            
+
             // tease apart the active filters from the predefined filters
             if (!provided_options.predefined_filters) {
                 provided_options["active_filters"] = provided_options._active_filters
@@ -632,7 +637,7 @@ function getUrlVars() {
                         } else {
                             // FIXME: this does not support pre-defined range queries
                             var predefined_values = provided_options.predefined_filters[field];
-                            for (var i=0; i < filter_list.length; i=i+1) {
+                            for (var i = 0; i < filter_list.length; i = i + 1) {
                                 var value = filter_list[i];
                                 if ($.inArray(value, predefined_values) === -1) {
                                     provided_options["active_filters"][field].push(value)
@@ -645,9 +650,9 @@ function getUrlVars() {
                     }
                 }
             }
-            
+
             // copy in the defaults to the individual facets when they are needed
-            for (var i=0; i < provided_options.facets.length; i=i+1) {
+            for (var i = 0; i < provided_options.facets.length; i = i + 1) {
                 var facet = provided_options.facets[i];
                 if (!("type" in facet)) { facet["type"] = provided_options.default_facet_type }
                 if (!("open" in facet)) { facet["open"] = provided_options.default_facet_open }
@@ -663,7 +668,7 @@ function getUrlVars() {
                 if (!("unit" in facet)) { facet["unit"] = provided_options.default_distance_unit }
                 if (!("lat" in facet)) { facet["lat"] = provided_options.default_distance_lat }
                 if (!("lon" in facet)) { facet["lon"] = provided_options.default_distance_lon }
-                if (!("value_function" in facet)) { facet["value_function"] = function(value) { return value } }
+                if (!("value_function" in facet)) { facet["value_function"] = function (value) { return value } }
                 if (!("interval" in facet)) { facet["interval"] = provided_options.default_date_histogram_interval }
                 if (!("hide_empty_date_bin" in facet)) { facet["hide_empty_date_bin"] = provided_options.default_hide_empty_date_bin }
                 if (!("sort" in facet)) { facet["sort"] = provided_options.default_date_histogram_sort }
@@ -671,57 +676,57 @@ function getUrlVars() {
                 if (!("short_display" in facet)) { facet["short_display"] = provided_options.default_short_display }
                 if (!("ignore_empty_string" in facet)) { facet["ignore_empty_string"] = provided_options.default_ignore_empty_string }
             }
-            
+
             return provided_options
         }
-        
+
         /******************************************************************
          * OPTIONS MANAGEMENT
          *****************************************************************/
 
         function uiFromOptions() {
             // set the current page size
-            options.behaviour_set_page_size(options, obj, {size: options.page_size});
-            
+            options.behaviour_set_page_size(options, obj, { size: options.page_size });
+
             // set the search order
             // NOTE: that this interface only supports single field ordering
-//DRE            var sorting = options.sort;
+            //DRE            var sorting = options.sort;
 
-//            for (var i = 0; i < sorting.length; i++) {
-//                var so = sorting[i];
-//                var fields = Object.keys(so);
-//                for (var j = 0; j < fields.length; j++) {
-//                    var dir = so[fields[j]]["order"];
-//                    options.behaviour_set_order(options, obj, {order: dir});
-//                    options.behaviour_set_order_by(options, obj, {orderby: fields[j]});
-//                    break
-//                }
-//                break
-//            }
-            
+            //            for (var i = 0; i < sorting.length; i++) {
+            //                var so = sorting[i];
+            //                var fields = Object.keys(so);
+            //                for (var j = 0; j < fields.length; j++) {
+            //                    var dir = so[fields[j]]["order"];
+            //                    options.behaviour_set_order(options, obj, {order: dir});
+            //                    options.behaviour_set_order_by(options, obj, {orderby: fields[j]});
+            //                    break
+            //                }
+            //                break
+            //            }
+
             // set the search field
-            options.behaviour_set_search_field(options, obj, {field : options.searchfield});
-            
+            options.behaviour_set_search_field(options, obj, { field: options.searchfield });
+
             // set the search string
-            options.behaviour_set_search_string(options, obj, {q: options.q});
-            
+            options.behaviour_set_search_string(options, obj, { q: options.q });
+
             // for each facet, set the facet size, order and and/or status
-            for (var i=0; i < options.facets.length; i=i+1) {
+            for (var i = 0; i < options.facets.length; i = i + 1) {
                 var f = options.facets[i];
                 if (f.hidden) {
                     continue;
                 }
-                options.behaviour_set_facet_size(options, obj, {facet : f});
-                options.behaviour_set_facet_sort(options, obj, {facet : f});
-                options.behaviour_set_facet_and_or(options, obj, {facet : f});
+                options.behaviour_set_facet_size(options, obj, { facet: f });
+                options.behaviour_set_facet_sort(options, obj, { facet: f });
+                options.behaviour_set_facet_and_or(options, obj, { facet: f });
             }
-            
+
             // for any existing filters, render them
             options.behaviour_set_selected_filters(options, obj);
         }
-        
+
         function urlFromOptions() {
-            
+
             if (options.pushstate && 'pushState' in window.history) {
                 var querypart = shareableUrl(options, true, true);
                 window.history.pushState("", "search", querypart);
@@ -730,7 +735,7 @@ function getUrlVars() {
             // also set the default shareable url at this point
             setShareableUrl()
         }
-        
+
         /******************************************************************
          * DEBUG
          *****************************************************************/
@@ -738,61 +743,61 @@ function getUrlVars() {
         function addDebug(msg, context) {
             $(".facetview_debug", context).show().find("textarea").append(msg + "\n\n")
         }
-        
+
         /**************************************************************
          * functions for managing search option events
          *************************************************************/
-        
+
         /////// paging /////////////////////////////////
-        
+
         // adjust how many results are shown
         function clickPageSize(event) {
             event.preventDefault();
-            var newhowmany = prompt('Currently displaying ' + options.page_size + 
+            var newhowmany = prompt('Currently displaying ' + options.page_size +
                 ' results per page. How many would you like instead?');
             if (newhowmany) {
                 options.page_size = parseInt(newhowmany);
                 options.from = 0;
-                options.behaviour_set_page_size(options, obj, {size: options.page_size});
+                options.behaviour_set_page_size(options, obj, { size: options.page_size });
                 doSearch();
             }
         }
 
         /////// start again /////////////////////////////////
-        
+
         // erase the current search and reload the window
         function clickStartAgain(event) {
             event.preventDefault();
             var base = window.location.href.split("?")[0];
             window.location.replace(base);
         }
-        
+
         /////// search ordering /////////////////////////////////
-        
+
         function clickOrder(event) {
             event.preventDefault();
-            
+
             // switch the sort options around
             if ($(this).attr('href') == 'desc') {
-                options.behaviour_set_order(options, obj, {order: "asc"})
+                options.behaviour_set_order(options, obj, { order: "asc" })
             } else {
-                options.behaviour_set_order(options, obj, {order: "desc"})
+                options.behaviour_set_order(options, obj, { order: "desc" })
             };
-            
+
             // synchronise the new sort with the options
             saveSortOption();
-            
+
             // reset the cursor and issue a search
             options.from = 0;
             doSearch();
         }
-        
+
         function changeOrderBy(event) {
             event.preventDefault();
-            
+
             // synchronise the new sort with the options
             saveSortOption();
-            
+
             // reset the cursor and issue a search
             options.from = 0;
             doSearch();
@@ -805,29 +810,29 @@ function getUrlVars() {
                 var sorting = [];
                 if (sortchoice.indexOf('[') === 0) {
                     sort_fields = JSON.parse(sortchoice.replace(/'/g, '"'));
-                    for ( var each = 0; each < sort_fields.length; each++ ) {
+                    for (var each = 0; each < sort_fields.length; each++) {
                         sf = sort_fields[each];
                         sortobj = {};
-                        sortobj[sf] = {'order': $('.facetview_order', obj).attr('href')};
+                        sortobj[sf] = { 'order': $('.facetview_order', obj).attr('href') };
                         sorting.push(sortobj);
                     }
                 } else {
                     sortobj = {};
-                    sortobj[sortchoice] = {'order': $('.facetview_order', obj).attr('href')};
+                    sortobj[sortchoice] = { 'order': $('.facetview_order', obj).attr('href') };
                     sorting.push(sortobj);
                 }
-                
+
                 options.sort = sorting;
             } else {
                 sortobj = {};
-                sortobj["_score"] = {'order': $('.facetview_order', obj).attr('href')};
+                sortobj["_score"] = { 'order': $('.facetview_order', obj).attr('href') };
                 sorting = [sortobj];
                 options.sort = sorting
             }
         }
-        
+
         /////// search fields /////////////////////////////////
-        
+
         // adjust the search field focus
         function changeSearchField(event) {
             event.preventDefault();
@@ -836,7 +841,7 @@ function getUrlVars() {
             options.searchfield = field;
             doSearch();
         };
-        
+
         // keyup in search box
         function keyupSearchText(event) {
             event.preventDefault();
@@ -845,7 +850,7 @@ function getUrlVars() {
             options.q = q;
             doSearch()
         }
-        
+
         // click of the search button
         function clickSearch() {
             event.preventDefault();
@@ -856,7 +861,7 @@ function getUrlVars() {
         }
 
         /////// share save link /////////////////////////////////
-        
+
         // show the current url with the result set as the source param
         function clickShareSave(event) {
             event.preventDefault();
@@ -885,9 +890,9 @@ function getUrlVars() {
             }
 
             var source = elasticSearchQuery({
-                "options" : options,
-                "include_facets" : options.include_facets_in_url,
-                "include_fields" : options.include_fields_in_url
+                "options": options,
+                "include_facets": options.include_facets_in_url,
+                "include_fields": options.include_fields_in_url
             });
             options.url_shortener(source, shortenCallback);
         }
@@ -909,32 +914,32 @@ function getUrlVars() {
                 options.behaviour_share_url(options, obj);
             }
         }
-        
+
         /**************************************************************
          * functions for handling facet events
          *************************************************************/
 
         /////// show/hide filter values /////////////////////////////////
-        
+
         // show the filter values
         function clickFilterShow(event) {
             event.preventDefault();
-            
+
             var name = $(this).attr("href");
             var facet = selectFacet(options, name);
             var el = facetElement("#facetview_filter_", name, obj);
-            
+
             facet.open = !facet.open;
             options.behaviour_toggle_facet_open(options, obj, facet)
         }
-        
+
         /////// change facet length /////////////////////////////////
-        
+
         // adjust how many results are shown
         function clickMoreFacetVals(event) {
             event.preventDefault();
             var morewhat = selectFacet(options, $(this).attr("href"));
-            if ('size' in morewhat ) {
+            if ('size' in morewhat) {
                 var currentval = morewhat['size'];
             } else {
                 var currentval = options.default_facet_size;
@@ -942,41 +947,41 @@ function getUrlVars() {
             var newmore = prompt('Currently showing ' + currentval + '. How many would you like instead?');
             if (newmore) {
                 morewhat['size'] = parseInt(newmore);
-                options.behaviour_set_facet_size(options, obj, {facet: morewhat})
+                options.behaviour_set_facet_size(options, obj, { facet: morewhat })
                 doSearch();
             }
         }
 
         /////// sorting facets /////////////////////////////////
-        
+
         function clickSort(event) {
             event.preventDefault();
             var sortwhat = selectFacet(options, $(this).attr('href'));
-            
+
             var cycle = {
-                "term" : "reverse_term",
-                "reverse_term" : "count",
-                "count" : "reverse_count",
+                "term": "reverse_term",
+                "reverse_term": "count",
+                "count": "reverse_count",
                 "reverse_count": "term"
             };
             sortwhat["order"] = cycle[sortwhat["order"]];
-            options.behaviour_set_facet_sort(options, obj, {facet: sortwhat});
+            options.behaviour_set_facet_sort(options, obj, { facet: sortwhat });
             doSearch();
         }
-        
+
         /////// AND vs OR on facet selection /////////////////////////////////
-        
+
         // function to switch filters to OR instead of AND
         function clickOr(event) {
             event.preventDefault();
             var orwhat = selectFacet(options, $(this).attr('href'));
-            
+
             var cycle = {
-                "OR" : "AND",
-                "AND" : "OR"
+                "OR": "AND",
+                "AND": "OR"
             }
             orwhat["logic"] = cycle[orwhat["logic"]];
-            options.behaviour_set_facet_and_or(options, obj, {facet: orwhat});
+            options.behaviour_set_facet_and_or(options, obj, { facet: orwhat });
             options.behaviour_set_selected_filters(options, obj);
             doSearch();
         }
@@ -996,7 +1001,7 @@ function getUrlVars() {
         }
 
         /////// facet values /////////////////////////////////
-        
+
         function setUIFacetResults(facet) {
             var el = facetElement("#facetview_filter_", facet["field"], obj);
 
@@ -1004,11 +1009,11 @@ function getUrlVars() {
             el.find(".facetview_date_histogram_short", obj).remove();
             el.find(".facetview_date_histogram_full", obj).remove();
             el.find('.facetview_filtervalue', obj).remove();
-            
+
             if (!("values" in facet)) {
                 return
             }
-            
+
             var frag = undefined;
             if (facet.type === "terms") {
                 frag = options.render_terms_facet_values(options, facet)
@@ -1023,14 +1028,14 @@ function getUrlVars() {
             if (frag) {
                 el.append(frag)
             }
-            
+
             options.behaviour_toggle_facet_open(options, obj, facet);
-            
+
             // FIXME: probably all bindings should come with an unbind first
             // enable filter selection
             $('.facetview_filterchoice', obj).unbind('click', clickFilterChoice);
             $('.facetview_filterchoice', obj).bind('click', clickFilterChoice);
-            
+
             // enable filter removal
             $('.facetview_filterselected', obj).unbind('click', clickClearFilter);
             $('.facetview_filterselected', obj).bind('click', clickClearFilter);
@@ -1039,12 +1044,12 @@ function getUrlVars() {
             $(".facetview_date_histogram_showless", obj).unbind("click", clickDHLess).bind("click", clickDHLess);
             $(".facetview_date_histogram_showall", obj).unbind("click", clickDHAll).bind("click", clickDHAll);
         }
-        
+
         /////// selected filters /////////////////////////////////
-        
+
         function clickFilterChoice(event) {
             event.preventDefault()
-            
+
             var field = $(this).attr("data-field");
             var facet = selectFacet(options, field);
             var value = {};
@@ -1067,30 +1072,30 @@ function getUrlVars() {
                 if (to) { value["to"] = to }
             }
             // FIXME: how to handle clicks on statistical facet (if that even makes sense) or terms_stats facet
-            
+
             // update the options and the filter display.  No need to update
             // the facet, as we'll issue a search straight away and it will
             // get updated automatically
             selectFilter(field, value);
             options.behaviour_set_selected_filters(options, obj);
-            
+
             // reset the result set to the beginning and search again
             options.from = 0;
             doSearch();
         }
-        
+
         function selectFilter(field, value) {
             // make space for the filter in the active filters list
             if (!(field in options.active_filters)) {
                 options.active_filters[field] = []
             }
-            
+
             var facet = selectFacet(options, field)
-            
+
             if (facet.type === "terms") {
                 // get the current values for that filter
                 var filter = options.active_filters[field];
-                if ($.inArray(value, filter) === -1 ) {
+                if ($.inArray(value, filter) === -1) {
                     filter.push(value)
                 }
             } else if (facet.type === "range") {
@@ -1106,7 +1111,7 @@ function getUrlVars() {
 
             // FIXME: statistical facet support here?
         }
-        
+
         function deSelectFilter(facet, field, value) {
             if (field in options.active_filters) {
                 var filter = options.active_filters[field];
@@ -1132,7 +1137,7 @@ function getUrlVars() {
             if ($(this).hasClass("facetview_inactive_link")) {
                 return
             }
-            
+
             var field = $(this).attr("data-field");
             var facet = selectFacet(options, field);
             var value = {};
@@ -1152,10 +1157,10 @@ function getUrlVars() {
                 value = $(this).attr("data-from");
             }
             // FIXMe: statistical facet
-            
+
             deSelectFilter(facet, field, value);
             publishSelectedFilters();
-            
+
             // reset the result set to the beginning and search again
             options.from = 0;
             doSearch();
@@ -1167,9 +1172,9 @@ function getUrlVars() {
             $('.facetview_filterselected', obj).unbind('click', clickClearFilter);
             $('.facetview_filterselected', obj).bind('click', clickClearFilter);
         }
-        
+
         function facetVisibility() {
-            $('.facetview_filters', obj).each(function() {
+            $('.facetview_filters', obj).each(function () {
                 var facet = selectFacet(options, $(this).attr('data-href'));
                 var values = "values" in facet ? facet["values"] : [];
                 var visible = !facet.disabled;
@@ -1217,11 +1222,11 @@ function getUrlVars() {
                 options.behaviour_facet_visibility(options, obj, facet, visible)
             });
         }
-        
+
         /**************************************************************
          * result metadata/paging handling
          *************************************************************/
-        
+
         // decrement result set
         function decrementPage(event) {
             event.preventDefault();
@@ -1232,7 +1237,7 @@ function getUrlVars() {
             options.from < 0 ? options.from = 0 : "";
             doSearch();
         };
-        
+
         // increment result set
         function incrementPage(event) {
             event.preventDefault();
@@ -1242,9 +1247,9 @@ function getUrlVars() {
             options.from = parseInt(options.from) + parseInt(options.page_size);
             doSearch();
         };
-        
+
         /////// display results metadata /////////////////////////////////
-        
+
         function setUIResultsMetadata() {
             if (!options.data.found) {
                 $('.facetview_metadata', obj).html("");
@@ -1255,16 +1260,16 @@ function getUrlVars() {
             $('.facetview_decrement', obj).bind('click', decrementPage);
             $('.facetview_increment', obj).bind('click', incrementPage);
         }
-        
+
         /**************************************************************
          * result set display
          *************************************************************/
-        
+
         function setUINotFound() {
             frag = options.render_not_found();
             $('#facetview_results', obj).html(frag);
         }
-        
+
         function setUISearchResults() {
             var frag = ""
             for (var i = 0; i < options.data.records.length; i++) {
@@ -1276,31 +1281,31 @@ function getUrlVars() {
             // FIXME: is possibly a debug feature?
             // $('.facetview_viewrecord', obj).bind('click', viewrecord);
         }
-        
+
         /**************************************************************
          * search handling
          *************************************************************/
-        
+
         function querySuccess(rawdata, results) {
             if (options.debug) {
                 addDebug(JSON.stringify(rawdata));
                 addDebug(JSON.stringify(results))
             }
-            
+
             // record the data coming from elasticsearch
             options.rawdata = rawdata;
             options.data = results;
-            
+
             // if a post search callback is provided, run it
             if (typeof options.post_search_callback == 'function') {
                 options.post_search_callback(options, obj);
             }
-            
+
             // if a pre-render callback is provided, run it
             if (typeof options.pre_render_callback == 'function') {
                 options.pre_render_callback(options, obj);
             }
-            
+
             // for each facet, get the results and add them to the page
             for (var each = 0; each < options.facets.length; each++) {
                 // get the facet, the field name and the size
@@ -1311,61 +1316,61 @@ function getUrlVars() {
 
                 var field = facet['field'];
                 var size = facet.hasOwnProperty("size") ? facet["size"] : options.default_facet_size;
-                
+
                 // get the records to be displayed, limited by the size and record against
                 // the options object
                 //DRE var records = results["facets"][field];
                 var records = rawdata.aggregations[field].buckets
                 // special rule for handling statistical, range and histogram facets
                 // DRE --- prob can remove next 2 lines of test. Also use rawdata.aggregations[field].buckets for records
-//                if (rawdata.aggregations[field].hasOwnProperty && records["_type"] === "statistical") {
-//                   facet["values"] = records
-//               } else {
-                    if (!records) { records = [] }
-                    if (size) { // this means you can set the size of a facet to something false (like, false, or 0, and size will be ignored)
-                        if (facet.type === "terms" && facet.ignore_empty_string) {
-                            facet["values"] = [];
-                            for (var i = 0; i < records.length; i++) {
-                                if (facet.values.length > size) {
-                                    break;
-                                }
-                                if (records[i].term !== "") {
-                                    facet["values"].push(records[i]);
-                                }
+                //                if (rawdata.aggregations[field].hasOwnProperty && records["_type"] === "statistical") {
+                //                   facet["values"] = records
+                //               } else {
+                if (!records) { records = [] }
+                if (size) { // this means you can set the size of a facet to something false (like, false, or 0, and size will be ignored)
+                    if (facet.type === "terms" && facet.ignore_empty_string) {
+                        facet["values"] = [];
+                        for (var i = 0; i < records.length; i++) {
+                            if (facet.values.length > size) {
+                                break;
                             }
-                        } else {
-                            facet["values"] = records.slice(0, size)
+                            if (records[i].term !== "") {
+                                facet["values"].push(records[i]);
+                            }
                         }
                     } else {
-                        facet["values"] = records
+                        facet["values"] = records.slice(0, size)
                     }
-//                }
+                } else {
+                    facet["values"] = records
+                }
+                //                }
 
                 // set the results on the page
                 if (!facet.hidden) {
                     setUIFacetResults(facet)
                 }
             }
-            
+
             // set the facet visibility
             facetVisibility();
-            
+
             // add the results metadata (paging, etc)
             setUIResultsMetadata();
-            
+
             // show the not found notification if necessary, otherwise render the results
             if (!options.data.found) {
                 setUINotFound()
             } else {
                 setUISearchResults()
             }
-            
+
             // if a post-render callback is provided, run it
             if (typeof options.post_render_callback == 'function') {
                 options.post_render_callback(options, obj);
             }
         }
-        
+
         function queryComplete(jqXHR, textStatus) {
             options.behaviour_finished_searching(options, obj);
             options.searching = false;
@@ -1384,7 +1389,7 @@ function getUrlVars() {
             }
             publishSelectedFilters();
         }
-        
+
         function doSearch() {
             // FIXME: does this have any weird side effects?
             // if a search is currently going on, don't do anything
@@ -1396,12 +1401,12 @@ function getUrlVars() {
 
             // invalidate the existing short url
             options.current_short_url = false;
-            
+
             // if a pre search callback is provided, run it
             if (typeof options.pre_search_callback === 'function') {
                 options.pre_search_callback(options, obj);
             }
-            
+
             // trigger any searching notification behaviour
             options.behaviour_show_searching(options, obj);
 
@@ -1410,69 +1415,71 @@ function getUrlVars() {
             pruneActiveFilters();
 
             // make the search query
-            var queryobj = elasticSearchQuery({"options" : options});
+            var queryobj = elasticSearchQuery({ "options": options });
             options.queryobj = queryobj
             if (options.debug) {
                 var querystring = serialiseQueryObject(queryobj);
                 addDebug(querystring)
             }
-            
+
             // augment the URL bar if possible, and the share/save link
             urlFromOptions();
-            
+
             // issue the query to elasticsearch
             doElasticSearchQuery({
                 search_url: options.search_url,
+                username: options.username,
+                password: options.password,
                 queryobj: queryobj,
                 datatype: options.datatype,
                 success: querySuccess,
                 complete: queryComplete
             })
         }
-        
+
         /**************************************************************
          * build all of the fragments that we want to render
          *************************************************************/
-        
+
         // set the externally facing facetview options
         $.fn.facetview.options = deriveOptions();
         var options = $.fn.facetview.options;
-        
+
         // render the facetview frame which will then be populated
         var thefacetview = options.render_the_facetview(options);
         var thesearchopts = options.render_search_options(options);
         var thefacets = options.render_facet_list(options);
         var searching = options.render_searching_notification(options);
-        
+
         // now create the plugin on the page for each div
         var obj = undefined;
-        return this.each(function() {
+        return this.each(function () {
             // get this object
             obj = $(this);
-            
+
             // what to do when ready to go
-            var whenready = function() {
+            var whenready = function () {
                 // append the facetview object to this object
                 obj.append(thefacetview);
-                
+
                 // add the search controls
                 $(".facetview_search_options_container", obj).html(thesearchopts);
-                
+
                 // add the facets (empty at this stage), then set their visibility, which will fall back to the
                 // worst case scenario for visibility - it means facets won't disappear after the search, only reappear
                 if (thefacets != "") {
                     $('#facetview_filters', obj).html(thefacets);
                     facetVisibility();
                 }
-                
+
                 // add the loading notification
                 if (searching != "") {
                     $(".facetview_searching", obj).html(searching)
                 }
-                
+
                 // populate all the page UI framework from the options
                 uiFromOptions(options);
-                
+
                 // bind the search control triggers
                 $(".facetview_startagain", obj).bind("click", clickStartAgain);
                 $('.facetview_pagesize', obj).bind('click', clickPageSize);
@@ -1484,18 +1491,18 @@ function getUrlVars() {
                 $('.facetview_force_search', obj).bind('click', clickSearch);
                 $('.facetview_shorten_url', obj).bind('click', clickShortenUrl);
                 $('.facetview_lengthen_url', obj).bind('click', clickLengthenUrl);
-                
+
                 // bind the facet control triggers
                 $('.facetview_filtershow', obj).bind('click', clickFilterShow);
                 $('.facetview_morefacetvals', obj).bind('click', clickMoreFacetVals);
                 $('.facetview_sort', obj).bind('click', clickSort);
                 $('.facetview_or', obj).bind('click', clickOr);
-                
+
                 // if a post initialisation callback is provided, run it
                 if (typeof options.post_init_callback === 'function') {
                     options.post_init_callback(options, obj);
                 }
-                
+
                 // if an initial search is requested, then issue it
                 if (options.initialsearch) { doSearch() }
             };
@@ -1506,5 +1513,5 @@ function getUrlVars() {
     // facetview options are declared as a function so that they can be retrieved
     // externally (which allows for saving them remotely etc)
     $.fn.facetview.options = {};
-    
+
 })(jQuery);

--- a/facetview2/jquery.facetview2.js
+++ b/facetview2/jquery.facetview2.js
@@ -227,12 +227,13 @@ function getUrlVars() {
             "search_url": "http://localhost:9200/_search",
 
             // username and password for http basic_auth - new for CU Boulder
-            "username": "anon",
-            "password": "anon",
+            // CRUCIAL! Only set the username:password for indexes that require it, otherwise it will fail with a 403
+            "username": null,
+            "password": null,
 
             // datatype for ajax requests to use - overall recommend using jsonp
             //DRE            "datatype" : "jsonp",
-            "datatype": "json",
+            //DRE "datatype": "json",
 
             // if set, should be either * or ~
             // if *, * will be prepended and appended to each string in the freetext search term

--- a/publications.html
+++ b/publications.html
@@ -28,7 +28,9 @@
     <script type="text/javascript">
         jQuery(document).ready(function ($) {
             $('.facet-view-simple').facetview({
-                search_url: 'https://experts.colorado.edu/es/fispubs-v1/_search',
+                search_url: 'https://search-experts-direct-cz3fpq4rlxcbn5z27vzq4mpzaa.us-east-2.es.amazonaws.com/fispubs-v1/_search',
+                username: 'anon',
+                password: 'anonyM0us!',
                 page_size: 20,
                 sort: [{ "publicationYear.keyword": { "order": "desc" } }],
                 sharesave_link: true,

--- a/publications.html
+++ b/publications.html
@@ -28,9 +28,7 @@
     <script type="text/javascript">
         jQuery(document).ready(function ($) {
             $('.facet-view-simple').facetview({
-                search_url: 'https://search-experts-pubs-unoedenr36fpm7alfpboeihcnq.us-east-2.es.amazonaws.com/fispubs-v1/_search',
-                username: "anon",
-                password: "anonyM0us!",
+                search_url: 'https://experts.colorado.edu/es/fispubs-v1/_search',
                 page_size: 20,
                 sort: [{ "publicationYear.keyword": { "order": "desc" } }],
                 sharesave_link: true,

--- a/publications.html
+++ b/publications.html
@@ -1,16 +1,19 @@
 <!DOCTYPE html>
 <html>
+
 <head lang="en">
     <meta charset="UTF-8">
     <title>Publication Browser</title>
 
-   <script type="text/javascript" src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.1/handlebars.min.js"></script>
+    <script type="text/javascript"
+        src="//cdnjs.cloudflare.com/ajax/libs/handlebars.js/4.0.1/handlebars.min.js"></script>
 
     <script type="text/javascript" src="facetview2/vendor/jquery/1.7.1/jquery-1.7.1.min.js"></script>
     <link rel="stylesheet" href="facetview2/vendor/bootstrap/css/bootstrap.min.css">
     <script type="text/javascript" src="facetview2/vendor/bootstrap/js/bootstrap.min.js"></script>
     <link rel="stylesheet" href="facetview2/vendor/jquery-ui-1.8.18.custom/jquery-ui-1.8.18.custom.css">
-    <script type="text/javascript" src="facetview2/vendor/jquery-ui-1.8.18.custom/jquery-ui-1.8.18.custom.min.js"></script>
+    <script type="text/javascript"
+        src="facetview2/vendor/jquery-ui-1.8.18.custom/jquery-ui-1.8.18.custom.min.js"></script>
 
     <script type="text/javascript" src="facetview2/es.js"></script>
     <script type="text/javascript" src="facetview2/bootstrap2.facetview.theme.js"></script>
@@ -19,14 +22,17 @@
     <link rel="stylesheet" href="facetview2/css/facetview.css">
     <link rel="stylesheet" href="browsers.css">
 
-   <script type='text/javascript' src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js?key=03b271189da4460eab0b761f3cd850fa'></script>
+    <script type='text/javascript'
+        src='https://d1bxh8uas1mnw7.cloudfront.net/assets/embed.js?key=03b271189da4460eab0b761f3cd850fa'></script>
 
     <script type="text/javascript">
-        jQuery(document).ready(function($) {
+        jQuery(document).ready(function ($) {
             $('.facet-view-simple').facetview({
                 search_url: 'https://search-experts-pubs-unoedenr36fpm7alfpboeihcnq.us-east-2.es.amazonaws.com/fispubs-v1/_search',
+                username: "anon",
+                password: "anonyM0us!",
                 page_size: 20,
-                sort: [{"publicationYear.keyword" : {"order" : "desc"}}],
+                sort: [{ "publicationYear.keyword": { "order": "desc" } }],
                 sharesave_link: true,
                 search_button: true,
                 default_freetext_fuzzify: "*",
@@ -34,33 +40,32 @@
                 default_facet_order: "count",
                 default_facet_size: 15,
                 facets: [
-                    {'field': 'mostSpecificType.keyword', 'display': 'Publication Type'},
-                    {'field': 'authors.name.keyword', 'size': 20, 'display': 'Author'},
-                    {'field': 'publishedIn.name.keyword', 'display': 'Published In'},
-                    {'field': 'publicationYear.keyword', 'display': 'Year Published', 'sort':'desc', "size" : 25},
+                    { 'field': 'mostSpecificType.keyword', 'display': 'Publication Type' },
+                    { 'field': 'authors.name.keyword', 'size': 20, 'display': 'Author' },
+                    { 'field': 'publishedIn.name.keyword', 'display': 'Published In' },
+                    { 'field': 'publicationYear.keyword', 'display': 'Year Published', 'sort': 'desc', "size": 25 },
                     //Example of date range histogram for future // {"field": "publicationYear", "display": "Publication Year", "type" : "date_histogram", "open" : false,"sort":"desc", "size" : 25},
-                    {'field': 'authors.organization.name.keyword', 'display': 'Author Organization'},
-                    {'field': 'authors.researchArea.name.keyword', 'display': 'Author Research Area'},
-                    {'field': 'cuscholarexists.keyword', 'display': 'Open Access'},
-		    {'field': 'amscore', 'display': 'Altmetric Range', "type" : "range", "range" : [{"to" : 0.001, "display" : "0 or no value"}, {"from" : 0.001, "to" :  100, "display" : "1 - 99"}, {"from" : 100, "to" : 500, "display" : "100 - 499"}, {"from" : 500, "display" : "500+"}], 'sort':'desc', "size" : 25},
+                    { 'field': 'authors.organization.name.keyword', 'display': 'Author Organization' },
+                    { 'field': 'authors.researchArea.name.keyword', 'display': 'Author Research Area' },
+                    { 'field': 'cuscholarexists.keyword', 'display': 'Open Access' },
+                    { 'field': 'amscore', 'display': 'Altmetric Range', "type": "range", "range": [{ "to": 0.001, "display": "0 or no value" }, { "from": 0.001, "to": 100, "display": "1 - 99" }, { "from": 100, "to": 500, "display": "100 - 499" }, { "from": 500, "display": "500+" }], 'sort': 'desc', "size": 25 },
                 ],
                 search_sortby: [
-                    {'display':'Title','field':'name.keyword'},
-                    {'display':'Date','field':'publicationDate'},
-                    {'display':'Altmetric Attention','field':'amscore'}
+                    { 'display': 'Title', 'field': 'name.keyword' },
+                    { 'display': 'Date', 'field': 'publicationDate' },
+                    { 'display': 'Altmetric Attention', 'field': 'amscore' }
                 ],
-                render_result_record: function(options, record)
-                {
+                render_result_record: function (options, record) {
 
                     var doi = record["doi"];
-                    var doiUrl = "https://dx.doi.org/"+record["doi"];
+                    var doiUrl = "https://dx.doi.org/" + record["doi"];
                     var escapedDOI = encodeURIComponent(doi).replace(/-/g, "--");
                     var scholarBadgeURL = "https://img.shields.io/badge/Open_Access-CU_Scholar-orange.svg?style=social&logo=open-access&logoColor=orange";
                     var doiBadgeURL = "https://img.shields.io/badge/DOI-" + escapedDOI + "-blue.svg?style=social&labelColor=black";
                     var html = "<tr><td>";
 
                     if (record["name"]) {
-                        html += "<strong><h4><a href=\""+record["uri"]+"\" target=\"_blank\">"+record["name"]+"</a></h4></strong>";
+                        html += "<strong><h4><a href=\"" + record["uri"] + "\" target=\"_blank\">" + record["name"] + "</a></h4></strong>";
                     }
 
 
@@ -77,7 +82,7 @@
 
                     if (record["subjectArea"]) {
                         html += "<br /><span>Subject Areas: ";
-                        for(var i = 0; i < record["subjectArea"].length; i++) {
+                        for (var i = 0; i < record["subjectArea"].length; i++) {
                             html += "<a href=\"" + record["subjectArea"][i]["uri"] + "\" target=\"_blank\">" + record["subjectArea"][i]["name"] + "</a>";
                             if (i < record["subjectArea"].length - 1) {
                                 html += "; ";
@@ -87,7 +92,7 @@
                     }
 
                     if (record["publishedIn"]) {
-                        html += "<br /><span>Published in: <a href=\""+record["publishedIn"]["uri"]+"\" target=\"_blank\">"+record["publishedIn"]["name"]+"</a></span>";
+                        html += "<br /><span>Published in: <a href=\"" + record["publishedIn"]["uri"] + "\" target=\"_blank\">" + record["publishedIn"]["name"] + "</a></span>";
                     }
 
 
@@ -103,7 +108,7 @@
 
 
                     if (record["presentedAt"]) {
-                        html += "<br /><span>Presented at: <a href=\""+record["presentedAt"]["uri"]+"\" target=\"_blank\">"+record["presentedAt"]["name"]+"</a></span>";
+                        html += "<br /><span>Presented at: <a href=\"" + record["presentedAt"]["uri"] + "\" target=\"_blank\">" + record["presentedAt"]["name"] + "</a></span>";
                     }
 
                     // Badges
@@ -112,17 +117,17 @@
 
                     html += "<div style=\"padding-right: 4px\">"
                     if (record["doi"]) {
-                        html += "<a href=\""+doiUrl+"\" target=\"_blank\"><img src=" + doiBadgeURL + "></a>";
-                    } 
+                        html += "<a href=\"" + doiUrl + "\" target=\"_blank\"><img src=" + doiBadgeURL + "></a>";
+                    }
                     html += "</div>"
 
                     html += "<div>"
                     if (record["cuscholar"]) {
-                        html += "<a href=\""+record["cuscholar"]+"\" target=\"_blank\"><img src=" + scholarBadgeURL + "></a>";
-                    } 
+                        html += "<a href=\"" + record["cuscholar"] + "\" target=\"_blank\"><img src=" + scholarBadgeURL + "></a>";
+                    }
                     html += "</div>"
 
-                   html += "<div class='altmetric-embed' data-link-target='_blank' data-hide-no-mentions='true' data-badge-popover='left' data-doi=\""+record["doi"]+"\"></div>"
+                    html += "<div class='altmetric-embed' data-link-target='_blank' data-hide-no-mentions='true' data-badge-popover='left' data-doi=\"" + record["doi"] + "\"></div>"
 
                     html += "</div>"
 
@@ -130,7 +135,7 @@
                     return html;
                 },
                 selected_filters_in_facet: true,
-                show_filter_field : true,
+                show_filter_field: true,
                 show_filter_logic: true,
             });
         });
@@ -138,47 +143,46 @@
     </script>
 
     <style type="text/css">
-
-
-        .facet-view-simple{
-            width:100%;
-            height:100%;
-            margin:20px auto 0 auto;
+        .facet-view-simple {
+            width: 100%;
+            height: 100%;
+            margin: 20px auto 0 auto;
         }
 
         .facetview_freetext.span4 {
-           width: 290px;
-           height: 12px;
+            width: 290px;
+            height: 12px;
         }
 
         legend {
-           display: none;
+            display: none;
         }
 
         #wrapper-content {
-          padding-top: 0px;
+            padding-top: 0px;
         }
 
         input {
             -webkit-box-shadow: none;
             box-shadow: none;
         }
-        
+
         .alert {
-           margin-top: 20px; 
+            margin-top: 20px;
         }
 
         .badge a {
-           float: left;
-           display: inline;
-           padding-right: 5px;
-           padding-top: 10px;
+            float: left;
+            display: inline;
+            padding-right: 5px;
+            padding-top: 10px;
         }
-
     </style>
 
 </head>
+
 <body>
-<div class="facet-view-simple"></div>
+    <div class="facet-view-simple"></div>
 </body>
+
 </html>


### PR DESCRIPTION
This PR allows the facetview javascript webpages to read AWS Elasticsearch endpoints with HTTP basic authentication. In this case AWS Elasticsearch with fine grained permissions.
Code works for Elasticsearch versions >= 7

There is a public username and password which I have included in the code because it's not a secret.

The code also has formatting changes littered throughout due to the vscode style formatter.

This has been tested against the endpoint.

To test, clone the code and just open publications.html - it should work.

Note - this repo won't work against the Elasticsearch running for CU Experts since that is version 6.x
Also, only the publications.html page was tested, it shouldn't be too much effort to modify and test the people.html page
