### PR TITLE
make bg transparent for better iframe integration

### DIFF
--- a/browsers.css
+++ b/browsers.css
@@ -1,17 +1,21 @@
 
+body {
+    background-color: transparent;
+}
+
 .btn-group.hidden {
-    display: none !important
+    display: none !important;
 }
 
 .facetview_filters.hidden {
-    display: none; !important;
+    display: none !important;
 }
 
 #facetview_filter_isDcoPublication {
-    display: none; !important;
+    display: none !important;
     visibility: hidden;
 }
 
 #facetview_filter_group_isDcoPublication {
-    display: none; !important;
+    display: none !important;
 }


### PR DESCRIPTION
Bootstrap sets the background color of `<body>` to `#ffffff`. This is not needed because the background of an html document is white by default, and the explicit background color declaration makes it so the page has less visual integration when including it in an `<iframe>` on a page that does not have a pure white background.

This PR overrides bootstrap's white background declaration by setting it to transparent, and fixes the `!important` syntax in the rest of the file.